### PR TITLE
Multiple errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,16 +3,17 @@ package main
 import (
 	"flag"
 	"fmt"
+	"os"
+	"strings"
+
 	"github.com/mbStavola/slydes/pkg/lang"
 	"github.com/mbStavola/slydes/render/html"
 	"github.com/mbStavola/slydes/render/native"
-	"os"
-	"strings"
 )
 
 func main() {
 	filename := flag.String("file", "", "slide to open")
-	output := flag.String("out", "html", "method of display (html, native)")
+	output := flag.String("out", "html", "method of display (html, noop, native)")
 	debug := flag.Bool("debug", false, "print debug info")
 
 	flag.Parse()
@@ -23,8 +24,8 @@ func main() {
 	} else if !strings.HasSuffix(*filename, ".sly") {
 		fmt.Print("Only .sly files are supported")
 		return
-	} else if *output != "native" && *output != "html" {
-		fmt.Print("Output must be either native or html")
+	} else if *output != "native" && *output != "html" && *output != "noop" {
+		fmt.Print("Output must be either html, native, or noop")
 		return
 	}
 
@@ -47,14 +48,16 @@ func main() {
 	}
 
 	switch *output {
-	case "native":
-		if err := native.Render(show); err != nil {
+	case "html":
+		if err := html.Render(show); err != nil {
 			fmt.Print(err)
 		}
 
 		break
-	case "html":
-		if err := html.Render(show); err != nil {
+	case "noop":
+		break
+	case "native":
+		if err := native.Render(show); err != nil {
 			fmt.Print(err)
 		}
 

--- a/main.go
+++ b/main.go
@@ -8,12 +8,11 @@ import (
 
 	"github.com/mbStavola/slydes/pkg/lang"
 	"github.com/mbStavola/slydes/render/html"
-	"github.com/mbStavola/slydes/render/native"
 )
 
 func main() {
 	filename := flag.String("file", "", "slide to open")
-	output := flag.String("out", "html", "method of display (html, noop, native)")
+	output := flag.String("out", "noop", "method of display (noop, html)")
 	debug := flag.Bool("debug", false, "print debug info")
 
 	flag.Parse()
@@ -25,7 +24,7 @@ func main() {
 		fmt.Print("Only .sly files are supported")
 		return
 	} else if *output != "native" && *output != "html" && *output != "noop" {
-		fmt.Print("Output must be either html, native, or noop")
+		fmt.Print("Output must be either noop or html")
 		return
 	}
 
@@ -48,16 +47,10 @@ func main() {
 	}
 
 	switch *output {
-	case "html":
-		if err := html.Render(show); err != nil {
-			fmt.Print(err)
-		}
-
-		break
 	case "noop":
 		break
-	case "native":
-		if err := native.Render(show); err != nil {
+	case "html":
+		if err := html.Render(show); err != nil {
 			fmt.Print(err)
 		}
 

--- a/pkg/lang/errors.go
+++ b/pkg/lang/errors.go
@@ -1,6 +1,35 @@
 package lang
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
+
+type ErrorInfoBundle struct {
+	errors []ErrorInfo
+}
+
+func newErrorInfoBundle() ErrorInfoBundle {
+	return ErrorInfoBundle{errors: make([]ErrorInfo, 0)}
+}
+
+func (b *ErrorInfoBundle) Add(err ErrorInfo) {
+	b.errors = append(b.errors, err)
+}
+
+func (b ErrorInfoBundle) HasErrors() bool {
+	return len(b.errors) > 0
+}
+
+func (b ErrorInfoBundle) Error() string {
+	builder := strings.Builder{}
+	for _, err := range b.errors {
+		builder.WriteString(err.Error())
+		builder.WriteByte('\n')
+	}
+
+	return builder.String()
+}
 
 type ErrorInfo struct {
 	line     uint

--- a/pkg/lang/lex.go
+++ b/pkg/lang/lex.go
@@ -94,7 +94,7 @@ func (lex DefaultLexer) Lex(reader io.Reader) ([]Token, error) {
 		switch char {
 		case '#':
 			_, _, _ = bufReader.ReadLine()
-			line += 1
+			line++
 
 			break
 		case '[':
@@ -226,7 +226,7 @@ func (lex DefaultLexer) Lex(reader io.Reader) ([]Token, error) {
 				if char == '-' && dashCounter == 2 {
 					break
 				} else if char == '-' {
-					dashCounter += 1
+					dashCounter++
 					continue
 				} else if dashCounter > 0 {
 					// If we've seen some number of dashes that is less than
@@ -303,7 +303,7 @@ func (lex DefaultLexer) Lex(reader io.Reader) ([]Token, error) {
 
 			break
 		case '\n':
-			line += 1
+			line++
 
 			break
 		default:

--- a/pkg/lang/lex.go
+++ b/pkg/lang/lex.go
@@ -3,6 +3,7 @@ package lang
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"io"
 	"strconv"
 	"strings"
@@ -14,6 +15,7 @@ type TokenType int
 const (
 	InvalidToken TokenType = iota
 	EOF
+	Skip
 
 	// Single Character
 	LeftParen
@@ -42,6 +44,7 @@ func (t TokenType) String() string {
 	return []string{
 		"InvalidToken",
 		"EOF",
+		"Skip",
 
 		"LeftParen",
 		"RightParen",
@@ -82,282 +85,314 @@ func NewDefaultLexer() DefaultLexer {
 }
 
 func (lex DefaultLexer) Lex(reader io.Reader) ([]Token, error) {
-	bufReader := bufio.NewReader(reader)
-	tokens := make([]Token, 0, 1024)
-	var line uint = 1
+	muncher := newRuneMuncher(reader)
+	errBundle := newErrorInfoBundle()
 
-	for char, _, err := bufReader.ReadRune(); err != io.EOF; char, _, err = bufReader.ReadRune() {
-		if err != nil {
+	tokens := make([]Token, 0, 1024)
+
+	for !muncher.atEnd() {
+		token, err := processRune(muncher)
+		if err != nil && errors.As(err, &ErrorInfo{}) {
+			errBundle.Add(err.(ErrorInfo))
+		} else if err != nil {
 			return tokens, err
 		}
 
-		switch char {
-		case '#':
-			_, _, _ = bufReader.ReadLine()
-			line++
-
-			break
-		case '[':
-			ty := SlideScope
-			if shouldEat, err := eatIf(bufReader, '['); err == io.EOF {
-				return tokens, lexemeErrorInfo(line, char, "Unexpected end of file")
-			} else if err != nil {
-				return tokens, err
-			} else if shouldEat {
-				ty = SubScope
-			}
-
-			title, err := bufReader.ReadString(']')
-			if err == io.EOF {
-				return tokens, lexemeErrorInfo(line, char, "Unterminated scope")
-			} else if err != nil {
-				return tokens, err
-			}
-
-			if shouldEat, err := eatIf(bufReader, ']'); err == io.EOF {
-				return tokens, lexemeErrorInfo(line, char, "Unexpected end of file")
-			} else if err != nil {
-				return tokens, err
-			} else if ty == SubScope && !shouldEat {
-				return tokens, lexemeErrorInfo(line, ']', "Subscope expected closing ']'")
-			} else if ty == SlideScope && shouldEat {
-				return tokens, lexemeErrorInfo(line, ']', "Dangling scope end")
-			}
-
-			tokens = append(tokens, Token{
-				Type:   ty,
-				line:   line,
-				lexeme: char,
-				// Cut off the dangling ] in the scope title
-				data: title[:len(title)-1],
-			})
-
-			break
-		case '(':
-			tokens = append(tokens, Token{
-				Type:   LeftParen,
-				line:   line,
-				lexeme: char,
-			})
-
-			break
-		case ')':
-			tokens = append(tokens, Token{
-				Type:   RightParen,
-				line:   line,
-				lexeme: char,
-			})
-
-			break
-		case '{':
-			tokens = append(tokens, Token{
-				Type:   LeftBrace,
-				line:   line,
-				lexeme: char,
-			})
-
-			break
-		case '}':
-			tokens = append(tokens, Token{
-				Type:   RightBrace,
-				line:   line,
-				lexeme: char,
-			})
-
-			break
-		case '@':
-			tokens = append(tokens, Token{
-				Type:   AtSign,
-				line:   line,
-				lexeme: char,
-			})
-
-			break
-		case '$':
-			tokens = append(tokens, Token{
-				Type:   DollarSign,
-				line:   line,
-				lexeme: char,
-			})
-
-			break
-		case '=':
-			tokens = append(tokens, Token{
-				Type:   EqualSign,
-				line:   line,
-				lexeme: char,
-			})
-
-			break
-		case ';':
-			tokens = append(tokens, Token{
-				Type:   Semicolon,
-				line:   line,
-				lexeme: char,
-			})
-
-		case ',':
-			tokens = append(tokens, Token{
-				Type:   Comma,
-				line:   line,
-				lexeme: char,
-			})
-
-			break
-		case '-':
-			if chars, err := bufReader.Peek(2); err == io.EOF {
-				return tokens, lexemeErrorInfo(line, char, "Unexpected end of file")
-			} else if err != nil {
-				return tokens, err
-			} else if string(chars[:]) != "--" {
-				return tokens, lexemeErrorInfo(line, char, "Malformed text block")
-			}
-
-			// Eat the starting dashes
-			if err = eatN(bufReader, 2); err != nil {
-				return tokens, err
-			}
-
-			text := strings.Builder{}
-			dashCounter := 0
-
-			// Read runes until we encounter three dashes in a row
-			for char, _, err := bufReader.ReadRune(); ; char, _, err = bufReader.ReadRune() {
-				if char == '-' && dashCounter == 2 {
-					break
-				} else if char == '-' {
-					dashCounter++
-					continue
-				} else if dashCounter > 0 {
-					// If we've seen some number of dashes that is less than
-					// three, write them to the text buffer and reset the count
-					dashes := bytes.Repeat([]byte("-"), dashCounter)
-					text.Write(dashes)
-					dashCounter = 0
-				}
-
-				if err != nil {
-					return tokens, err
-				}
-
-				text.WriteRune(char)
-			}
-
-			tokens = append(tokens, Token{
-				Type:   Text,
-				line:   line,
-				lexeme: char,
-				data:   text.String(),
-			})
-
-			break
-		case '"':
-			str, err := bufReader.ReadString('"')
-			if err == io.EOF {
-				return tokens, simpleErrorInfo(line, "Unterminated String")
-			} else if err != nil {
-				return tokens, err
-			}
-
-			tokens = append(tokens, Token{
-				Type:   String,
-				line:   line,
-				lexeme: char,
-				// Cut off the dangling " in the string
-				data: str[:len(str)-1],
-			})
-
-			break
-		case '0':
-		case '1', '2', '3', '4', '5', '6', '7', '8', '9':
-			num := strings.Builder{}
-			num.WriteRune(char)
-
-			for char, _, err := bufReader.ReadRune(); ; char, _, err = bufReader.ReadRune() {
-				if err != nil {
-					return tokens, err
-				}
-
-				if !unicode.IsNumber(char) {
-					bufReader.UnreadRune()
-					break
-				}
-
-				num.WriteRune(char)
-			}
-
-			data, err := strconv.ParseUint(num.String(), 10, 8)
-			if err != nil {
-				return tokens, err
-			}
-
-			tokens = append(tokens, Token{
-				Type:   Integer,
-				line:   line,
-				lexeme: char,
-				data:   uint8(data),
-			})
-
-			break
-		case ' ', '\t', '\r':
-
-			break
-		case '\n':
-			line++
-
-			break
-		default:
-			if unicode.IsLetter(char) {
-				ident := strings.Builder{}
-				ident.WriteRune(char)
-
-				for char, _, err := bufReader.ReadRune(); ; char, _, err = bufReader.ReadRune() {
-					if err != nil {
-						return tokens, err
-					}
-
-					if !unicode.IsLetter(char) && !unicode.IsNumber(char) {
-						bufReader.UnreadRune()
-						break
-					}
-
-					ident.WriteRune(char)
-				}
-
-				tokens = append(tokens, Token{
-					Type:   Identifier,
-					line:   line,
-					lexeme: char,
-					data:   ident.String(),
-				})
-
-				break
-			}
-
-			return tokens, lexemeErrorInfo(line, char, "Unexpected character")
+		if token.Type == Skip {
+			continue
 		}
+
+		tokens = append(tokens, token)
+	}
+
+	if errBundle.HasErrors() {
+		return tokens, errBundle
 	}
 
 	return tokens, nil
 }
 
+func processRune(muncher *runeMuncher) (Token, error) {
+	char, _, err := muncher.ReadRune()
+	if err != nil {
+		return Token{}, err
+	}
+
+	switch char {
+	case '#':
+		_, _, _ = muncher.ReadLine()
+		muncher.newLine()
+		return Token{Type: Skip}, nil
+
+	case '[':
+		ty := SlideScope
+		if shouldEat, err := muncher.eatIf('['); err == io.EOF {
+			return Token{}, lexemeErrorInfo(muncher.line, char, "Unexpected end of file")
+		} else if err != nil {
+			return Token{}, err
+		} else if shouldEat {
+			ty = SubScope
+		}
+
+		title, err := muncher.ReadString(']')
+		if err == io.EOF {
+			return Token{}, lexemeErrorInfo(muncher.line, char, "Unterminated scope")
+		} else if err != nil {
+			return Token{}, err
+		}
+
+		if shouldEat, err := muncher.eatIf(']'); err == io.EOF {
+			return Token{}, lexemeErrorInfo(muncher.line, char, "Unexpected end of file")
+		} else if err != nil {
+			return Token{}, err
+		} else if ty == SubScope && !shouldEat {
+			return Token{}, lexemeErrorInfo(muncher.line, ']', "Subscope expected closing ']'")
+		} else if ty == SlideScope && shouldEat {
+			return Token{}, lexemeErrorInfo(muncher.line, ']', "Dangling scope end")
+		}
+
+		return Token{
+			Type:   ty,
+			line:   muncher.line,
+			lexeme: char,
+			// Cut off the dangling ] in the scope title
+			data: title[:len(title)-1],
+		}, nil
+
+	case '(':
+		return Token{
+			Type:   LeftParen,
+			line:   muncher.line,
+			lexeme: char,
+		}, nil
+
+	case ')':
+		return Token{
+			Type:   RightParen,
+			line:   muncher.line,
+			lexeme: char,
+		}, nil
+
+	case '{':
+		return Token{
+			Type:   LeftBrace,
+			line:   muncher.line,
+			lexeme: char,
+		}, nil
+
+	case '}':
+		return Token{
+			Type:   RightBrace,
+			line:   muncher.line,
+			lexeme: char,
+		}, nil
+
+	case '@':
+		return Token{
+			Type:   AtSign,
+			line:   muncher.line,
+			lexeme: char,
+		}, nil
+
+	case '$':
+		return Token{
+			Type:   DollarSign,
+			line:   muncher.line,
+			lexeme: char,
+		}, nil
+
+	case '=':
+		return Token{
+			Type:   EqualSign,
+			line:   muncher.line,
+			lexeme: char,
+		}, nil
+
+	case ';':
+		return Token{
+			Type:   Semicolon,
+			line:   muncher.line,
+			lexeme: char,
+		}, nil
+
+	case ',':
+		return Token{
+			Type:   Comma,
+			line:   muncher.line,
+			lexeme: char,
+		}, nil
+
+	case '-':
+		if chars, err := muncher.Peek(2); err == io.EOF {
+			return Token{}, lexemeErrorInfo(muncher.line, char, "Unexpected end of file")
+		} else if err != nil {
+			return Token{}, err
+		} else if string(chars[:]) != "--" {
+			return Token{}, lexemeErrorInfo(muncher.line, char, "Malformed text block")
+		}
+
+		// Eat the starting dashes
+		if err = muncher.eatN(2); err != nil {
+			return Token{}, err
+		}
+
+		text := strings.Builder{}
+		dashCounter := 0
+
+		// Read runes until we encounter three dashes in a row
+		for char, _, err := muncher.ReadRune(); ; char, _, err = muncher.ReadRune() {
+			if char == '-' && dashCounter == 2 {
+				break
+			} else if char == '-' {
+				dashCounter++
+				continue
+			} else if dashCounter > 0 {
+				// If we've seen some number of dashes that is less than
+				// three, write them to the text buffer and reset the count
+				dashes := bytes.Repeat([]byte("-"), dashCounter)
+				text.Write(dashes)
+				dashCounter = 0
+			}
+
+			if err != nil {
+				return Token{}, err
+			}
+
+			text.WriteRune(char)
+		}
+
+		return Token{
+			Type:   Text,
+			line:   muncher.line,
+			lexeme: char,
+			data:   text.String(),
+		}, nil
+
+	case '"':
+		str, err := muncher.ReadString('"')
+		if err == io.EOF {
+			return Token{}, simpleErrorInfo(muncher.line, "Unterminated String")
+		} else if err != nil {
+			return Token{}, err
+		}
+
+		return Token{
+			Type:   String,
+			line:   muncher.line,
+			lexeme: char,
+			// Cut off the dangling " in the string
+			data: str[:len(str)-1],
+		}, nil
+
+	case '0':
+	case '1', '2', '3', '4', '5', '6', '7', '8', '9':
+		num := strings.Builder{}
+		num.WriteRune(char)
+
+		for char, _, err := muncher.ReadRune(); ; char, _, err = muncher.ReadRune() {
+			if err != nil {
+				return Token{}, err
+			}
+
+			if !unicode.IsNumber(char) {
+				muncher.UnreadRune()
+				break
+			}
+
+			num.WriteRune(char)
+		}
+
+		data, err := strconv.ParseUint(num.String(), 10, 8)
+		if err != nil {
+			return Token{}, err
+		}
+
+		return Token{
+			Type:   Integer,
+			line:   muncher.line,
+			lexeme: char,
+			data:   uint8(data),
+		}, nil
+
+	case ' ', '\t', '\r':
+		return Token{Type: Skip}, nil
+
+	case '\n':
+		muncher.newLine()
+		return Token{Type: Skip}, nil
+
+	default:
+		if unicode.IsLetter(char) {
+			ident := strings.Builder{}
+			ident.WriteRune(char)
+
+			for char, _, err := muncher.ReadRune(); ; char, _, err = muncher.ReadRune() {
+				if err != nil {
+					return Token{}, err
+				}
+
+				if !unicode.IsLetter(char) && !unicode.IsNumber(char) {
+					muncher.UnreadRune()
+					break
+				}
+
+				ident.WriteRune(char)
+			}
+
+			return Token{
+				Type:   Identifier,
+				line:   muncher.line,
+				lexeme: char,
+				data:   ident.String(),
+			}, nil
+		}
+
+		return Token{}, lexemeErrorInfo(muncher.line, char, "Unexpected character")
+	}
+
+	panic("unreachable")
+}
+
+type runeMuncher struct {
+	line uint
+	*bufio.Reader
+}
+
+func newRuneMuncher(reader io.Reader) *runeMuncher {
+	r := new(runeMuncher)
+
+	r.line = 1
+	r.Reader = bufio.NewReader(reader)
+
+	return r
+}
+
+func (r *runeMuncher) atEnd() bool {
+	_, err := r.Peek(1)
+	return err == io.EOF
+}
+
+func (r *runeMuncher) newLine() {
+	r.line++
+}
+
 // Helper function to conditionally eat a lexeme if it matches
 // the expected rune
-func eatIf(reader *bufio.Reader, expected rune) (bool, error) {
-	if actual, _, err := reader.ReadRune(); err != nil {
+func (r *runeMuncher) eatIf(expected rune) (bool, error) {
+	if actual, _, err := r.ReadRune(); err != nil {
 		// TODO(Matt): Would it be more correct to unread the rune here?
 		return false, err
 	} else if actual == expected {
 		return true, nil
 	}
 
-	return false, reader.UnreadRune()
+	return false, r.UnreadRune()
 }
 
 // Helper function to discard a specified number of runes
-func eatN(reader *bufio.Reader, n int) error {
+func (r *runeMuncher) eatN(n int) error {
 	for i := 0; i < n; i++ {
-		if _, _, err := reader.ReadRune(); err != nil {
+		if _, _, err := r.ReadRune(); err != nil {
 			return err
 		}
 	}

--- a/pkg/lang/sly.go
+++ b/pkg/lang/sly.go
@@ -1,9 +1,10 @@
 package lang
 
 import (
-	"github.com/mbStavola/slydes/pkg/types"
 	"io"
 	"strings"
+
+	"github.com/mbStavola/slydes/pkg/types"
 )
 
 // This type represents a three phase "compiler" for

--- a/render/native/render.go
+++ b/render/native/render.go
@@ -1,9 +1,0 @@
-package native
-
-import (
-	"github.com/mbStavola/slydes/pkg/types"
-)
-
-func Render(show types.Show) error {
-	return nil
-}


### PR DESCRIPTION
Support displaying multiple errors instead of aborting on the first one.

Additionally, added a `noop` output mode and made it the default. This allows you to simply compile your Sly presentation for testing purposes.