### PR TITLE
Mutability

### DIFF
--- a/SLY.md
+++ b/SLY.md
@@ -11,8 +11,13 @@ Comments start with `#` and ignore the rest of the line
 You can define variables with Sly, the syntax is pretty simple:
 
 ```
-variableName = 1;
+let variableName = 1;
+mut otherVarName = "f";
 ```
+
+A variable declaration is composed of three parts: mutability binding, identifier, and an initial value.
+
+A variable can either be bound as immutable (`let`) or mutable (`mut`). Immutable variables cannot be reassigned after initialization whereas mutables ones can.
 
 The identifier for the variable must start with a letter but can contain any alphanumeric character subsequently.
 
@@ -23,11 +28,13 @@ All variable declarations must end with a semicolon.
 You can use a variable in an attribute declaration or possibly in another variable declaration.
 
 ```
-variable1 = "hello";
-variable2 = variable1;
+let variable1 = "hello";
+let variable2 = variable1;
 ```
 
-Variables are global and are not scoped to slides or blocks. They will be overwritten on reassignment!
+Variables are global and are not scoped to slides or blocks.
+
+Variables may be shadowed by redeclaring them.
 
 ## Attribute Declaration
 

--- a/examples/basic.sly
+++ b/examples/basic.sly
@@ -9,9 +9,9 @@
 # either HTML, PDF, or (eventually) PPT
 
 # Setup our color palette
-coolGray = (26, 83, 92);
-paleGreen = (247, 255, 247);
-tealBlue = (78, 205, 196);
+let coolGray = (26, 83, 92);
+mut paleGreen = (247, 255, 247);
+let tealBlue = (78, 205, 196);
 
 # Set the default styles for the rest
 # of the presentation

--- a/pkg/lang/errors.go
+++ b/pkg/lang/errors.go
@@ -34,6 +34,7 @@ func (b ErrorInfoBundle) Error() string {
 type ErrorInfo struct {
 	line     uint
 	location string
+	stage    stage
 	message  string
 }
 
@@ -49,18 +50,31 @@ func lexemeErrorInfo(line uint, lexeme rune, message string) ErrorInfo {
 	return ErrorInfo{
 		line:     line,
 		location: fmt.Sprintf(" at '%c'", lexeme),
+		stage:    lexing,
 		message:  message,
 	}
 }
 
-func tokenErrorInfo(token Token, message string) ErrorInfo {
+func tokenErrorInfo(token Token, stage stage, message string) ErrorInfo {
 	return ErrorInfo{
 		line:     token.line,
 		location: fmt.Sprintf(" at '%c'", token.lexeme),
+		stage:    stage,
 		message:  message,
 	}
 }
 
 func (err ErrorInfo) Error() string {
-	return fmt.Sprintf("[line=%d] Error%s: %s", err.line, err.location, err.message)
+	stage := ""
+	if err.stage != unspecified {
+		stage = fmt.Sprintf(" %s ", err.stage)
+	}
+
+	return fmt.Sprintf(
+		"[line=%d]%sError%s: %s",
+		err.line,
+		stage,
+		err.location,
+		err.message,
+	)
 }

--- a/pkg/lang/lex.go
+++ b/pkg/lang/lex.go
@@ -28,6 +28,10 @@ const (
 	EqualSign
 	Comma
 
+	// Keywords
+	Let
+	Mut
+
 	// Special
 	SlideScope
 	SubScope
@@ -55,6 +59,9 @@ func (t TokenType) String() string {
 		"DollarSign",
 		"EqualSign",
 		"Comma",
+
+		"Let",
+		"Mut",
 
 		"SlideScope",
 		"SubScope",
@@ -221,6 +228,38 @@ func processRune(muncher *runeMuncher) (Token, error) {
 			line:   muncher.line,
 			lexeme: char,
 		}, nil
+
+	case 'l':
+		if chars, err := muncher.Peek(2); err == io.EOF {
+			return Token{}, lexemeErrorInfo(muncher.line, char, "Unexpected end of file")
+		} else if err != nil {
+			return Token{}, err
+		} else if string(chars[:]) == "et" {
+			muncher.eatN(2)
+			return Token{
+				Type:   Let,
+				line:   muncher.line,
+				lexeme: char,
+			}, nil
+		}
+
+		// Intentional fallthrough-- this might be an identifier
+
+	case 'm':
+		if chars, err := muncher.Peek(2); err == io.EOF {
+			return Token{}, lexemeErrorInfo(muncher.line, char, "Unexpected end of file")
+		} else if err != nil {
+			return Token{}, err
+		} else if string(chars[:]) == "ut" {
+			muncher.eatN(2)
+			return Token{
+				Type:   Mut,
+				line:   muncher.line,
+				lexeme: char,
+			}, nil
+		}
+
+		// Intentional fallthrough-- this might be an identifier
 
 	case '-':
 		if chars, err := muncher.Peek(2); err == io.EOF {

--- a/pkg/lang/sly.go
+++ b/pkg/lang/sly.go
@@ -7,6 +7,24 @@ import (
 	"github.com/mbStavola/slydes/pkg/types"
 )
 
+type stage int
+
+const (
+	unspecified stage = iota
+	lexing
+	parsing
+	compilation
+)
+
+func (s stage) String() string {
+	return []string{
+		"",
+		"Lexing",
+		"Parsing",
+		"Compilation",
+	}[s]
+}
+
 // This type represents a three phase "compiler" for
 // the Sly language which can produce an instance of Show
 type Sly struct {

--- a/pkg/lang/sly_test.go
+++ b/pkg/lang/sly_test.go
@@ -1,10 +1,11 @@
 package lang
 
 import (
-	"github.com/mbStavola/slydes/pkg/types"
 	"image/color"
 	"strings"
 	"testing"
+
+	"github.com/mbStavola/slydes/pkg/types"
 )
 
 var sly = NewSly()
@@ -13,9 +14,9 @@ func TestSimplePresentation(t *testing.T) {
 	source := `
 	# This is a very simple slideshow
 	# Hopefully everything works as intended
-	coolGray = (26, 83, 92);
-	paleGreen = (247, 255, 247,);
-	tealBlue = (78, 205, 196, 255);
+	let coolGray = (26, 83, 92);
+	let paleGreen = (247, 255, 247,);
+	let tealBlue = (78, 205, 196, 255);
 
 	---Welcome!---
 
@@ -140,7 +141,7 @@ Text
 
 func TestMacro(t *testing.T) {
 	source := `
-	red = "red";
+	let red = "red";
 	$styleMacro = {
 		@backgroundColor = red;
 		@fontColor = "blue";


### PR DESCRIPTION
Introduce the concept of mutability to Sly.

Now, all variables must be declared with either `let` (immutable) or `mut` (mutable). The compilation phase will track mutability for declaration and assignment.

Variables can still be shadowed by redeclaring them.

Additionally, errors now track what stage they occurred at.